### PR TITLE
Drools 1629

### DIFF
--- a/drools-beliefs/pom.xml
+++ b/drools-beliefs/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-beliefs</artifactId>

--- a/drools-compiler/pom.xml
+++ b/drools-compiler/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-compiler</artifactId>

--- a/drools-core/pom.xml
+++ b/drools-core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-core</artifactId>

--- a/drools-core/src/main/java/org/drools/core/marshalling/impl/IdentityPlaceholderResolverStrategy.java
+++ b/drools-core/src/main/java/org/drools/core/marshalling/impl/IdentityPlaceholderResolverStrategy.java
@@ -16,7 +16,7 @@
 
 package org.drools.core.marshalling.impl;
 
-import org.kie.api.marshalling.ObjectMarshallingStrategy;
+import org.kie.api.marshalling.NamedObjectMarshallingStrategy;
 import org.kie.api.marshalling.ObjectMarshallingStrategyAcceptor;
 
 import java.io.IOException;
@@ -28,24 +28,35 @@ import java.util.Map;
 
 public class IdentityPlaceholderResolverStrategy
     implements
-    ObjectMarshallingStrategy {
+    NamedObjectMarshallingStrategy {
 
     private Map<Integer, Object> ids;
     private Map<Object, Integer> objects;
 
+    private String name = IdentityPlaceholderResolverStrategy.class.getName();
     private ObjectMarshallingStrategyAcceptor acceptor;
     
     public IdentityPlaceholderResolverStrategy(ObjectMarshallingStrategyAcceptor acceptor) {
         this.acceptor = acceptor;
         this.ids = new HashMap<Integer, Object>();
         this.objects = new IdentityHashMap<Object, Integer>();
+        this.name += this.acceptor.toString();
     }
 
     public IdentityPlaceholderResolverStrategy(ObjectMarshallingStrategyAcceptor acceptor, Map<Integer, Object> ids) {
         this(acceptor);
         setIds(ids);
     }
+    
+    public IdentityPlaceholderResolverStrategy(ObjectMarshallingStrategyAcceptor acceptor, Map<Integer, Object> ids, String name) {
+        this(acceptor);
+        setIds(ids);
+        this.name = name;
+    }
 
+    public String getName(){
+    	return this.name;
+    }
     public Object read(ObjectInputStream os) throws IOException,
                                                        ClassNotFoundException {
         int id = os.readInt();

--- a/drools-core/src/main/java/org/drools/core/marshalling/impl/ObjectMarshallingStrategyStoreImpl.java
+++ b/drools-core/src/main/java/org/drools/core/marshalling/impl/ObjectMarshallingStrategyStoreImpl.java
@@ -16,15 +16,39 @@
 
 package org.drools.core.marshalling.impl;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import org.drools.core.rule.constraint.MvelConstraint;
 import org.drools.core.util.StringUtils;
 import org.kie.api.marshalling.ObjectMarshallingStrategy;
+import org.kie.api.marshalling.NamedObjectMarshallingStrategy;
 import org.kie.api.marshalling.ObjectMarshallingStrategyStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ObjectMarshallingStrategyStoreImpl implements ObjectMarshallingStrategyStore {
-    private ObjectMarshallingStrategy[] strategiesList;
+	private static final Logger logger = LoggerFactory.getLogger(ObjectMarshallingStrategyStoreImpl.class);
+
+	private ObjectMarshallingStrategy[] strategiesList;
     
     public ObjectMarshallingStrategyStoreImpl(ObjectMarshallingStrategy[] strategiesList) {
         this.strategiesList = strategiesList;
+        Set<String> names = new HashSet<String>();
+        for( ObjectMarshallingStrategy strategy : strategiesList ){
+        	String name;
+        	if( strategy instanceof NamedObjectMarshallingStrategy ){
+        		name = ((NamedObjectMarshallingStrategy)strategy).getName();
+        	}else{
+        		name = strategy.getClass().getName();
+        	}
+        	if( names.contains( name ) ){
+        		logger.warn( "Multiple ObjectMarshallingStrategies with the same name:" + name + " strange behaviour could occurr");
+        	}else{
+        		names.add( name );
+        	}
+        }
+        names.clear();
     }
    
     // Old marshalling algorithm methods
@@ -60,7 +84,11 @@ public class ObjectMarshallingStrategyStoreImpl implements ObjectMarshallingStra
         }
         ObjectMarshallingStrategy objectMarshallingStrategy = null; 
         for( int i = 0; i < this.strategiesList.length; ++i ) { 
-           if( strategiesList[i].getClass().getName().equals(strategyClassName) ) {
+        
+        	if( strategiesList[i] instanceof NamedObjectMarshallingStrategy 
+         		   && ((NamedObjectMarshallingStrategy)strategiesList[i]).getName().equals(strategyClassName )){
+         	   return strategiesList[i];
+            }else if( strategiesList[i].getClass().getName().equals(strategyClassName) ) {
                return strategiesList[i];
            }
         }

--- a/drools-core/src/main/java/org/drools/core/marshalling/impl/PersisterHelper.java
+++ b/drools-core/src/main/java/org/drools/core/marshalling/impl/PersisterHelper.java
@@ -16,10 +16,18 @@
 
 package org.drools.core.marshalling.impl;
 
-import com.google.protobuf.ByteString;
-import com.google.protobuf.ByteString.Output;
-import com.google.protobuf.ExtensionRegistry;
-import com.google.protobuf.Message;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.InvalidKeyException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map.Entry;
+
 import org.drools.core.beliefsystem.simple.BeliefSystemLogicalCallback;
 import org.drools.core.common.DroolsObjectInputStream;
 import org.drools.core.common.DroolsObjectOutputStream;
@@ -36,19 +44,13 @@ import org.drools.core.spi.Tuple;
 import org.drools.core.util.Drools;
 import org.drools.core.util.KeyStoreHelper;
 import org.kie.api.marshalling.ObjectMarshallingStrategy;
+import org.kie.api.marshalling.NamedObjectMarshallingStrategy;
 import org.kie.api.marshalling.ObjectMarshallingStrategy.Context;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.security.InvalidKeyException;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.SignatureException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map.Entry;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.ByteString.Output;
+import com.google.protobuf.ExtensionRegistry;
+import com.google.protobuf.Message;
 
 public class PersisterHelper {
     public static WorkingMemoryAction readWorkingMemoryAction(MarshallerReaderContext context) throws IOException,
@@ -239,9 +241,13 @@ public class PersisterHelper {
     private static void writeStrategiesIndex(MarshallerWriteContext context,
                                              ProtobufMessages.Header.Builder _header) throws IOException {
         for( Entry<ObjectMarshallingStrategy,Integer> entry : context.usedStrategies.entrySet() ) {
+        	String name = entry.getKey().getClass().getName() ;
+        	if( entry.getKey() instanceof NamedObjectMarshallingStrategy ){
+        		name = ((NamedObjectMarshallingStrategy)entry.getKey()).getName();
+        	}
             Builder _strat = ProtobufMessages.Header.StrategyIndex.newBuilder()
                                      .setId( entry.getValue().intValue() )
-                                     .setName( entry.getKey().getClass().getName() );
+                                     .setName( name );
             Context ctx = context.strategyContext.get( entry.getKey() );
             if( ctx != null ) {
                 Output os = ByteString.newOutput();

--- a/drools-core/src/main/java/org/drools/core/marshalling/impl/SerializablePlaceholderResolverStrategy.java
+++ b/drools-core/src/main/java/org/drools/core/marshalling/impl/SerializablePlaceholderResolverStrategy.java
@@ -22,19 +22,30 @@ import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.kie.api.marshalling.ObjectMarshallingStrategy;
+import org.kie.api.marshalling.NamedObjectMarshallingStrategy;
 import org.kie.api.marshalling.ObjectMarshallingStrategyAcceptor;
 
 public class SerializablePlaceholderResolverStrategy
     implements
-    ObjectMarshallingStrategy {
+    NamedObjectMarshallingStrategy {
 
     private int index;
     
     private ObjectMarshallingStrategyAcceptor acceptor;
+    private String name = SerializablePlaceholderResolverStrategy.class.getName();
     
     public SerializablePlaceholderResolverStrategy(ObjectMarshallingStrategyAcceptor acceptor) {
         this.acceptor = acceptor;
+        this.name += acceptor.toString();
+    }
+    
+    public SerializablePlaceholderResolverStrategy(String name, ObjectMarshallingStrategyAcceptor acceptor) {
+        this(acceptor );
+        this.name = name;
+    }
+    
+    public String getName(){
+    	return this.name;
     }
     
     public int getIndex() {

--- a/drools-core/src/test/java/org/drools/core/marshalling/impl/NamedCustomMarshallingStrategy.java
+++ b/drools-core/src/test/java/org/drools/core/marshalling/impl/NamedCustomMarshallingStrategy.java
@@ -1,0 +1,22 @@
+package org.drools.core.marshalling.impl;
+
+import java.util.Map;
+
+import org.kie.api.marshalling.NamedObjectMarshallingStrategy;
+import org.kie.api.marshalling.ObjectMarshallingStrategyAcceptor;
+
+public class NamedCustomMarshallingStrategy extends IdentityPlaceholderResolverStrategy implements NamedObjectMarshallingStrategy{
+
+
+	private String name;
+	
+	public NamedCustomMarshallingStrategy(String name, ObjectMarshallingStrategyAcceptor acceptor, Map<Integer,Object> data ) {
+		super(acceptor, data);
+		this.name = name;
+	}
+	
+	@Override
+	public String getName() {
+		return name;
+	}
+}

--- a/drools-core/src/test/java/org/drools/core/marshalling/impl/ObjectMarshallingStrategyStoreTest.java
+++ b/drools-core/src/test/java/org/drools/core/marshalling/impl/ObjectMarshallingStrategyStoreTest.java
@@ -1,0 +1,211 @@
+package org.drools.core.marshalling.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.drools.core.SessionConfiguration;
+import org.drools.core.common.DefaultFactHandle;
+import org.drools.core.impl.EnvironmentFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.kie.api.KieBaseConfiguration;
+import org.kie.api.conf.EventProcessingOption;
+import org.kie.api.marshalling.ObjectMarshallingStrategy;
+import org.kie.api.marshalling.ObjectMarshallingStrategyAcceptor;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.EnvironmentName;
+import org.kie.api.runtime.KieSessionConfiguration;
+import org.kie.api.runtime.rule.FactHandle;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.builder.conf.RuleEngineOption;
+import org.kie.internal.marshalling.MarshallerFactory;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+
+public class ObjectMarshallingStrategyStoreTest {
+
+	private class Thing{
+		int id;
+		String value;
+		Thing( int id, String value ){
+			this.id = id;
+			this.value = value;
+		}
+		
+		public boolean equals( Object thing )
+		{
+			return thing!= null && thing instanceof Thing && ((Thing)thing).id == this.id;
+		}
+		
+		public String toString(){
+			return "Thing:"+id+","+value;
+		}
+	}
+	
+	@Test 
+	public void avoidMixingOfObjectMarshallingStrategiesOfTheSameClass() throws IOException, ClassNotFoundException {
+
+		Environment env = EnvironmentFactory.newEnvironment();
+		final Thing entityOne = new Thing( 1, "Object 1" );
+		final Thing entityTwo = new Thing( 2, "Object 2" );
+		
+		Collection srcItems = new ArrayList();
+		srcItems.add( entityOne ); 
+		srcItems.add( entityTwo );
+		
+		ObjectMarshallingStrategy[] strats = new ObjectMarshallingStrategy[] {
+				new IdentityPlaceholderResolverStrategy(new ObjectMarshallingStrategyAcceptor() {
+
+					@Override
+					public boolean accept(Object object) {
+						return entityOne.equals(object);
+					}
+				}, Collections.singletonMap(entityOne.id, (Object) entityOne)),
+				new IdentityPlaceholderResolverStrategy(new ObjectMarshallingStrategyAcceptor() {
+
+					@Override
+					public boolean accept(Object object) {
+						return entityTwo.equals(object);
+					}
+				}, Collections.singletonMap(entityTwo.id, (Object) entityTwo)) };
+
+		env.set(EnvironmentName.OBJECT_MARSHALLING_STRATEGIES, strats);
+
+		KieSessionConfiguration ksc = SessionConfiguration.getDefaultInstance();
+
+		final KieBaseConfiguration kbconf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
+
+		kbconf.setOption(EventProcessingOption.STREAM);
+		kbconf.setOption(RuleEngineOption.PHREAK);
+
+		KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase(kbconf);
+
+		StatefulKnowledgeSession ks = kbase.newStatefulKnowledgeSession(ksc, env);
+		
+		
+		ks.insert( entityOne ); 
+		ks.insert( entityTwo );
+		
+		ProtobufMarshaller marshaller = (ProtobufMarshaller) MarshallerFactory.newMarshaller(kbase, strats);
+		
+		// Serialize object
+		final byte[] b1;
+		{
+			ByteArrayOutputStream bos = new ByteArrayOutputStream();
+			marshaller.marshall(bos, ks, System.currentTimeMillis());
+			b1 = bos.toByteArray();
+			bos.close();
+		}
+
+		// Deserialize object
+		StatefulKnowledgeSession ksession2;
+		{
+			ByteArrayInputStream bais = new ByteArrayInputStream(b1);
+			try{
+				ksession2 = marshaller.unmarshall(bais, ks.getSessionConfiguration(), ks.getEnvironment());
+				Collection items = ksession2.getFactHandles();
+				Assert.assertTrue( items.size() == 2 );
+				for( Object item : items ){
+					FactHandle factHandle = (FactHandle)item;
+					Assert.assertTrue( srcItems.contains( ((DefaultFactHandle)factHandle).getObject() ) );
+				}
+			}catch( RuntimeException npe ){
+				// Here ocurrs the bug that shows that NamedObjectMarshallingStrategies are required.
+				Assert.fail( "This error only happens if identity ObjectMarshallingStrategy use old name" );
+			}finally{
+				bais.close();
+			}
+			
+			
+		}
+	}
+
+	@Test
+	public void allowMixingOfNamedObjectMarshallingStrategiesWithTheSameClass()
+			throws IOException, ClassNotFoundException {
+
+		Environment env = EnvironmentFactory.newEnvironment();
+		final Thing entityOne = new Thing( 1, "Object 1" );
+		final Thing entityTwo = new Thing( 2, "Object 2" );
+		final Thing entityThree = new Thing( 3, "Object 3" );
+		
+		Collection srcItems = new ArrayList();
+		srcItems.add( entityOne ); 
+		srcItems.add( entityTwo );
+		srcItems.add( entityThree );
+		
+		
+		ObjectMarshallingStrategy[] strats = new ObjectMarshallingStrategy[] {
+				new NamedCustomMarshallingStrategy("ofObject1", new ObjectMarshallingStrategyAcceptor() {
+
+					@Override
+					public boolean accept(Object object) {
+						return entityOne.equals(object);
+					}
+				}, Collections.singletonMap(entityOne.id, (Object) entityOne)),
+				new NamedCustomMarshallingStrategy("ofObject2", new ObjectMarshallingStrategyAcceptor() {
+
+					@Override
+					public boolean accept(Object object) {
+						return entityTwo.equals(object);
+					}
+				}, Collections.singletonMap(entityTwo.id, (Object) entityTwo)),
+				
+				new IdentityPlaceholderResolverStrategy(new ObjectMarshallingStrategyAcceptor() {
+
+					@Override
+					public boolean accept(Object object) {
+						return entityThree.equals(object);
+					}
+				}, Collections.singletonMap(3, (Object) entityThree))  };
+
+		env.set(EnvironmentName.OBJECT_MARSHALLING_STRATEGIES, strats);
+
+		KieSessionConfiguration ksc = SessionConfiguration.getDefaultInstance();
+
+		final KieBaseConfiguration kbconf = KnowledgeBaseFactory.newKnowledgeBaseConfiguration();
+
+		kbconf.setOption(EventProcessingOption.STREAM);
+		kbconf.setOption(RuleEngineOption.PHREAK);
+
+		KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase(kbconf);
+
+		StatefulKnowledgeSession ks = kbase.newStatefulKnowledgeSession(ksc, env);
+
+		
+		ks.insert( entityOne ); 
+		ks.insert( entityTwo );
+		ks.insert( entityThree );
+		
+		ProtobufMarshaller marshaller = null;
+		marshaller = (ProtobufMarshaller) MarshallerFactory.newMarshaller(kbase, strats);
+
+		// Serialize object
+		final byte[] b1;
+		{
+			ByteArrayOutputStream bos = new ByteArrayOutputStream();
+			marshaller.marshall(bos, ks, System.currentTimeMillis());
+			b1 = bos.toByteArray();
+			bos.close();
+		}
+
+		// Deserialize object
+		StatefulKnowledgeSession ksession2;
+		{
+			ByteArrayInputStream bais = new ByteArrayInputStream(b1);
+			ksession2 = marshaller.unmarshall(bais, ks.getSessionConfiguration(), ks.getEnvironment());
+			bais.close();
+			
+			Collection items = ksession2.getFactHandles();
+			for( Object item : items ){
+				FactHandle factHandle = (FactHandle)item;
+				//Here we can validate that using named ObjectMarshallingStrategies can read properly the serialized objects
+				Assert.assertTrue( srcItems.contains( ((DefaultFactHandle)factHandle).getObject() ) );
+			}
+		}
+	}
+}

--- a/drools-decisiontables/pom.xml
+++ b/drools-decisiontables/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-decisiontables</artifactId>

--- a/drools-distribution/pom.xml
+++ b/drools-distribution/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-distribution</artifactId>

--- a/drools-examples-api/default-kiesession-from-file/pom.xml
+++ b/drools-examples-api/default-kiesession-from-file/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>default-kiesession-from-file</artifactId>

--- a/drools-examples-api/default-kiesession/pom.xml
+++ b/drools-examples-api/default-kiesession/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>default-kiesession</artifactId>

--- a/drools-examples-api/kie-module-from-multiple-files/pom.xml
+++ b/drools-examples-api/kie-module-from-multiple-files/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>kie-module-from-multiple-files</artifactId>

--- a/drools-examples-api/kiebase-inclusion/pom.xml
+++ b/drools-examples-api/kiebase-inclusion/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>kiebase-inclusion</artifactId>

--- a/drools-examples-api/kiecontainer-from-kierepo/pom.xml
+++ b/drools-examples-api/kiecontainer-from-kierepo/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>kiecontainer-from-kierepo</artifactId>

--- a/drools-examples-api/kiefilesystem-example/pom.xml
+++ b/drools-examples-api/kiefilesystem-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>kiefilesystem-example</artifactId>

--- a/drools-examples-api/kiemodulemodel-example/pom.xml
+++ b/drools-examples-api/kiemodulemodel-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>kiemodulemodel-example</artifactId>

--- a/drools-examples-api/multiple-kbases/pom.xml
+++ b/drools-examples-api/multiple-kbases/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>multiple-kbases</artifactId>

--- a/drools-examples-api/named-kiesession-from-file/pom.xml
+++ b/drools-examples-api/named-kiesession-from-file/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <name>Drools API examples - Named KieSession from File</name>

--- a/drools-examples-api/named-kiesession/pom.xml
+++ b/drools-examples-api/named-kiesession/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>named-kiesession</artifactId>

--- a/drools-examples-api/pom.xml
+++ b/drools-examples-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-examples-api</artifactId>

--- a/drools-examples-api/reactive-kiesession/pom.xml
+++ b/drools-examples-api/reactive-kiesession/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-api</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>reactive-kiesession</artifactId>

--- a/drools-examples-cdi/cdi-example-with-inclusion/pom.xml
+++ b/drools-examples-cdi/cdi-example-with-inclusion/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-cdi</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>cdi-example-with-inclusion</artifactId>

--- a/drools-examples-cdi/cdi-example/pom.xml
+++ b/drools-examples-cdi/cdi-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-cdi</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>cdi-example</artifactId>

--- a/drools-examples-cdi/pom.xml
+++ b/drools-examples-cdi/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-examples-cdi</artifactId>

--- a/drools-examples/pom.xml
+++ b/drools-examples/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-examples</artifactId>

--- a/drools-jsr94/pom.xml
+++ b/drools-jsr94/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-jsr94</artifactId>

--- a/drools-persistence-jpa/pom.xml
+++ b/drools-persistence-jpa/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-persistence-jpa</artifactId>

--- a/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/marshaller/JPAPlaceholderResolverStrategy.java
+++ b/drools-persistence-jpa/src/main/java/org/drools/persistence/jpa/marshaller/JPAPlaceholderResolverStrategy.java
@@ -35,28 +35,34 @@ import org.drools.core.marshalling.impl.MarshallerWriteContext;
 import org.drools.core.marshalling.impl.ProcessMarshallerWriteContext;
 import org.drools.persistence.TransactionAware;
 import org.drools.persistence.TransactionManager;
-import org.kie.api.marshalling.ObjectMarshallingStrategy;
+import org.kie.api.marshalling.NamedObjectMarshallingStrategy;
 import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.EnvironmentName;
 import org.kie.internal.runtime.Cacheable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class JPAPlaceholderResolverStrategy implements ObjectMarshallingStrategy, TransactionAware, Cacheable {
+public class JPAPlaceholderResolverStrategy implements NamedObjectMarshallingStrategy, TransactionAware, Cacheable {
     private static Logger log = LoggerFactory.getLogger(JPAPlaceholderResolverStrategy.class);
     private EntityManagerFactory emf;
     private ClassLoader classLoader;
 
     private boolean closeEmf = false;
-
+    private String name = JPAPlaceholderResolverStrategy.class.getName();
     private static final ThreadLocal<EntityManager> persister = new ThreadLocal<EntityManager>();
     
     public JPAPlaceholderResolverStrategy(Environment env) {
-        this.emf = (EntityManagerFactory) env.get(EnvironmentName.ENTITY_MANAGER_FACTORY);
+        this( (EntityManagerFactory) env.get(EnvironmentName.ENTITY_MANAGER_FACTORY) );
     }
 
     public JPAPlaceholderResolverStrategy(EntityManagerFactory emf) {
         this.emf = emf;
+        this.name += this.emf.toString();
+    }
+    
+    public JPAPlaceholderResolverStrategy(String name, EntityManagerFactory emf) {
+        this( emf );
+        this.name = name;
     }
 
     public JPAPlaceholderResolverStrategy(String persistenceUnit, ClassLoader cl) {
@@ -73,6 +79,11 @@ public class JPAPlaceholderResolverStrategy implements ObjectMarshallingStrategy
             Thread.currentThread().setContextClassLoader(tccl);
         }
         this.classLoader = cl;
+        this.name += persistenceUnit;
+    }
+    
+    public String getName( ){
+    	return this.name;
     }
     
     public boolean accept(Object object) {

--- a/drools-pmml/pom.xml
+++ b/drools-pmml/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
 

--- a/drools-reteoo/pom.xml
+++ b/drools-reteoo/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-reteoo</artifactId>

--- a/drools-scorecards/pom.xml
+++ b/drools-scorecards/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-scorecards</artifactId>

--- a/drools-templates/pom.xml
+++ b/drools-templates/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-templates</artifactId>

--- a/drools-verifier/pom.xml
+++ b/drools-verifier/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-verifier</artifactId>

--- a/drools-workbench-models/drools-workbench-models-commons/pom.xml
+++ b/drools-workbench-models/drools-workbench-models-commons/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-workbench-models</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-workbench-models-commons</artifactId>

--- a/drools-workbench-models/drools-workbench-models-datamodel-api/pom.xml
+++ b/drools-workbench-models/drools-workbench-models-datamodel-api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-workbench-models</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-workbench-models-datamodel-api</artifactId>

--- a/drools-workbench-models/drools-workbench-models-guided-dtable/pom.xml
+++ b/drools-workbench-models/drools-workbench-models-guided-dtable/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-workbench-models</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-workbench-models-guided-dtable</artifactId>

--- a/drools-workbench-models/drools-workbench-models-guided-dtree/pom.xml
+++ b/drools-workbench-models/drools-workbench-models-guided-dtree/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-workbench-models</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-workbench-models/drools-workbench-models-guided-scorecard/pom.xml
+++ b/drools-workbench-models/drools-workbench-models-guided-scorecard/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-workbench-models</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-workbench-models-guided-scorecard</artifactId>

--- a/drools-workbench-models/drools-workbench-models-guided-template/pom.xml
+++ b/drools-workbench-models/drools-workbench-models-guided-template/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-workbench-models</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-workbench-models-guided-template</artifactId>

--- a/drools-workbench-models/drools-workbench-models-test-scenarios/pom.xml
+++ b/drools-workbench-models/drools-workbench-models-test-scenarios/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>drools-workbench-models</artifactId>
     <groupId>org.drools</groupId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-workbench-models-test-scenarios</artifactId>

--- a/drools-workbench-models/pom.xml
+++ b/drools-workbench-models/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>drools-workbench-models</artifactId>

--- a/kie-ci-osgi/pom.xml
+++ b/kie-ci-osgi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools</artifactId>
     <groupId>org.drools</groupId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-ci/pom.xml
+++ b/kie-ci/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>drools</artifactId>
     <groupId>org.drools</groupId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-test-util/pom.xml
+++ b/kie-test-util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <groupId>org.kie</groupId>

--- a/knowledge-api-legacy5-adapter/pom.xml
+++ b/knowledge-api-legacy5-adapter/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
   </parent>
 
   <artifactId>knowledge-api</artifactId>

--- a/knowledge-api-legacy5-adapter/src/main/java/org/drools/marshalling/NamedObjectMarshallingStrategy.java
+++ b/knowledge-api-legacy5-adapter/src/main/java/org/drools/marshalling/NamedObjectMarshallingStrategy.java
@@ -1,0 +1,6 @@
+package org.drools.marshalling;
+
+public interface NamedObjectMarshallingStrategy extends ObjectMarshallingStrategy {
+
+	public String getName();
+}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-parent-with-dependencies</artifactId>
-    <version>6.4.0-SNAPSHOT</version>
+    <version>6.4.0.Final</version>
     <!-- relativePath causes out-of-date problems on hudson slaves -->
     <!--<relativePath>../droolsjbpm-build-bootstrap/pom.xml</relativePath>-->
   </parent>


### PR DESCRIPTION
Adding NamedObjectMarshallingStrategy to avoid mixing of Marshilling strateges while using more than one ObjectMarshallingStrategies with the same implementation class.