### PR TITLE
Avoid losing Transformable Resources not being updated on database.

### DIFF
--- a/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/jta/JtaTransactionManager.java
+++ b/drools-persistence/drools-persistence-api/src/main/java/org/drools/persistence/jta/JtaTransactionManager.java
@@ -204,6 +204,7 @@ public class JtaTransactionManager
         // and still be associated with current thread
         // See WFLY-4327
         int status = getStatus();
+        boolean result = false;
         if ( status == TransactionManager.STATUS_ROLLEDBACK ) {
             logger.debug("Cleanup of transaction that has been rolled back previously");
             rollback(true);
@@ -212,7 +213,7 @@ public class JtaTransactionManager
         if ( status == TransactionManager.STATUS_NO_TRANSACTION ) {
             try {
                 getUt().begin();
-                return true;
+                result =  true;
             } catch ( Exception e ) {
                 // special WAS handling for cached UserTrnsactions
                 if (e.getClass().getName().equals("javax.ejb.EJBException")) {
@@ -224,7 +225,7 @@ public class JtaTransactionManager
 
                     try {
                         this.ut.begin();
-                        return true;
+                        result =  true;
                     } catch (Exception ex) {
                         logger.warn( "Unable to begin transaction", e);
                         throw new RuntimeException( "Unable to begin transaction",  e );
@@ -234,9 +235,20 @@ public class JtaTransactionManager
                     logger.warn( "Unable to begin transaction", e);
                     throw new RuntimeException( "Unable to begin transaction", e );
                 }
+            }finally{
+                if( result ){
+	            	if( transactionResources.get() != null && transactionResources.get().size() > 0 ){
+	                	logger.warn( "Found transaction resources not properly cleared, clearing them!" );
+	                	Map<Object,Object> map = transactionResources.get();
+	                	for( Object key : map.keySet() ){
+	                		logger.warn( "Item[" + key + "]:" + map.get(key) );
+	                	}
+	                	transactionResources.get().clear();
+	                }
+            	}
             }
         } 
-        return false;
+        return result;
     }
 
     public void commit(boolean transactionOwner) {
@@ -247,9 +259,10 @@ public class JtaTransactionManager
                 logger.warn( "Unable to commit transaction", e);
                 throw new RuntimeException( "Unable to commit transaction",
                                             e );
+            }finally{
+                transactionResources.get().clear();
             }
         }
-        transactionResources.get().clear();
     }
     
     public void rollback(boolean transactionOwner) {


### PR DESCRIPTION
We have found that sequences of SingleSessionCommandService executions and the clearing of transactionResouces loses some Transformable Resouces not being updated on database.

Proposed solution solves the issue.